### PR TITLE
Fix player records not persisting due to UUID identity comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Player records loaded from storage on plugin enable are now found correctly on rejoin. Previously, `PersistentData` compared player UUIDs with `==` instead of `.equals()`, so a UUID re-parsed from disk (or from a new `Player` object) never matched the loaded record, silently orphaning existing kill/death data.
+
 ## [Initial Release]
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.4</version>
                 <executions>
@@ -79,6 +84,12 @@
             <artifactId>ponder</artifactId>
             <version>1.1</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/dansplugins/kdrtracker/data/PersistentData.java
+++ b/src/main/java/dansplugins/kdrtracker/data/PersistentData.java
@@ -30,7 +30,7 @@ public class PersistentData {
 
     public PlayerRecord getPlayerRecord(UUID playerUUID) throws PlayerRecordNotFoundException {
         for (PlayerRecord playerRecord : playerRecords) {
-            if (playerRecord.getPlayerUUID() == playerUUID) {
+            if (playerRecord.getPlayerUUID().equals(playerUUID)) {
                 return playerRecord;
             }
         }

--- a/src/test/java/dansplugins/kdrtracker/data/PersistentDataTest.java
+++ b/src/test/java/dansplugins/kdrtracker/data/PersistentDataTest.java
@@ -1,0 +1,56 @@
+package dansplugins.kdrtracker.data;
+
+import dansplugins.kdrtracker.exceptions.PlayerRecordNotFoundException;
+import dansplugins.kdrtracker.objects.PlayerRecord;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Daniel McCoy Stephenson
+ *
+ * Regression coverage for player records loaded from storage (e.g. on plugin
+ * enable) being found again by value-equal UUIDs, rather than by the same
+ * UUID object instance.
+ */
+class PersistentDataTest {
+
+    private PlayerRecord buildLoadedPlayerRecord(UUID playerUUID) {
+        Map<String, String> data = new HashMap<>();
+        data.put("playerUUID", playerUUID.toString());
+        data.put("kills", "3");
+        data.put("deaths", "1");
+        return new PlayerRecord(data);
+    }
+
+    @Test
+    void getPlayerRecord_findsRecordByEqualButDistinctUUIDInstance() throws PlayerRecordNotFoundException {
+        UUID playerUUID = UUID.randomUUID();
+        PersistentData persistentData = new PersistentData();
+        persistentData.addPlayerRecord(buildLoadedPlayerRecord(playerUUID));
+
+        // Simulate a freshly-parsed UUID instance, as would come from a new
+        // Player object on rejoin after the record was loaded from disk.
+        UUID lookupUUID = UUID.fromString(playerUUID.toString());
+        assertNotSame(playerUUID, lookupUUID, "test setup should use a distinct UUID instance");
+
+        PlayerRecord found = persistentData.getPlayerRecord(lookupUUID);
+        assertEquals(playerUUID, found.getPlayerUUID());
+        assertEquals(3, found.getKills());
+        assertEquals(1, found.getDeaths());
+    }
+
+    @Test
+    void playerHasRecord_isTrueForEqualButDistinctUUIDInstance() {
+        UUID playerUUID = UUID.randomUUID();
+        PersistentData persistentData = new PersistentData();
+        persistentData.addPlayerRecord(buildLoadedPlayerRecord(playerUUID));
+
+        UUID lookupUUID = UUID.fromString(playerUUID.toString());
+        assertTrue(persistentData.playerHasRecord(lookupUUID));
+    }
+}


### PR DESCRIPTION
## Summary
- `PersistentData.getPlayerRecord(UUID)` compared player UUIDs with `==` (reference identity) instead of `.equals()` (value equality).
- A `UUID` freshly parsed from disk on `onEnable` (or newly obtained from a rejoining `Player` object) is a distinct object instance from the one stored on the matching `PlayerRecord`, even when the underlying value is identical — so the `==` check always failed for records reloaded from storage.
- Effect: `JoinListener` believed returning players had no record, so a fresh 0/0 `PlayerRecord` was created for them on every rejoin, silently orphaning their previously-saved kill/death data. This matches the reported symptom in #2 ("data is not properly loaded in").
- Fixed by switching the comparison to `.equals()`.
- This is the first test added to the project, so a `junit-jupiter` test-scope dependency and an explicit `maven-surefire-plugin` version (3.2.5, needed for Maven 3.6.3 to auto-detect the JUnit 5 platform) were added to `pom.xml`. Added `src/test/java/dansplugins/kdrtracker/data/PersistentDataTest.java` covering the lookup behavior directly against `PersistentData`/`PlayerRecord`, with no Bukkit mocking required.
- Added a `[Unreleased]` entry to `CHANGELOG.md`.

## Test plan
- [x] `mvn clean package` — full build green, including the new tests.
- [x] Regression-verified: with the fix reverted (`git stash` on `PersistentData.java` only), both new tests fail (`AssertionFailedError` / `PlayerRecordNotFoundException`); with the fix restored, both pass.
- [x] Confirmed via `git stash` that the transitive `junit:junit:4.13.1` dependency already existed in the shaded jar before this change (pulled in by `ponder`), so this PR does not add new bloat to the shipped plugin jar — the new `junit-jupiter` dependency is test-scope only and excluded from `mvn package`'s shaded jar.

Closes #2

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
