### PR TITLE
Add unit tests for PlayerRecord ratio and accounting logic

### DIFF
--- a/src/test/java/dansplugins/kdrtracker/objects/PlayerRecordTest.java
+++ b/src/test/java/dansplugins/kdrtracker/objects/PlayerRecordTest.java
@@ -1,0 +1,69 @@
+package dansplugins.kdrtracker.objects;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Daniel McCoy Stephenson
+ *
+ * Regression coverage for PlayerRecord's kill/death accounting and ratio math.
+ */
+class PlayerRecordTest {
+
+    private PlayerRecord buildPlayerRecord(UUID playerUUID, int kills, int deaths) {
+        Map<String, String> data = new HashMap<>();
+        data.put("playerUUID", playerUUID.toString());
+        data.put("kills", "" + kills);
+        data.put("deaths", "" + deaths);
+        return new PlayerRecord(data);
+    }
+
+    @Test
+    void getRatio_returnsKillsAsWholeNumber_whenDeathsIsZero() {
+        PlayerRecord playerRecord = buildPlayerRecord(UUID.randomUUID(), 5, 0);
+        assertEquals(5.0, playerRecord.getRatio());
+    }
+
+    @Test
+    void getRatio_returnsZero_whenKillsAndDeathsAreBothZero() {
+        PlayerRecord playerRecord = buildPlayerRecord(UUID.randomUUID(), 0, 0);
+        assertEquals(0.0, playerRecord.getRatio());
+    }
+
+    @Test
+    void getRatio_returnsQuotient_whenDeathsIsNonZero() {
+        PlayerRecord playerRecord = buildPlayerRecord(UUID.randomUUID(), 3, 2);
+        assertEquals(1.5, playerRecord.getRatio());
+    }
+
+    @Test
+    void incrementKills_increasesKillsByOne() {
+        PlayerRecord playerRecord = buildPlayerRecord(UUID.randomUUID(), 0, 0);
+        playerRecord.incrementKills();
+        assertEquals(1, playerRecord.getKills());
+    }
+
+    @Test
+    void incrementDeaths_increasesDeathsByOne() {
+        PlayerRecord playerRecord = buildPlayerRecord(UUID.randomUUID(), 0, 0);
+        playerRecord.incrementDeaths();
+        assertEquals(1, playerRecord.getDeaths());
+    }
+
+    @Test
+    void save_roundTripsThroughLoad() {
+        UUID playerUUID = UUID.randomUUID();
+        PlayerRecord playerRecord = buildPlayerRecord(playerUUID, 4, 2);
+
+        PlayerRecord reloaded = new PlayerRecord(playerRecord.save());
+
+        assertEquals(playerUUID, reloaded.getPlayerUUID());
+        assertEquals(4, reloaded.getKills());
+        assertEquals(2, reloaded.getDeaths());
+    }
+}


### PR DESCRIPTION
## Summary

- Test coverage was added for `PlayerRecord`, which previously had zero tests despite containing the only division-by-zero-guarded math in the domain model (`getRatio()`).
- Cases covered: the zero-deaths guard (ratio returns kills as a whole number), the zero-kills-and-zero-deaths edge case, the normal quotient path, the `incrementKills`/`incrementDeaths` helpers, and a `save()`/`load()` round trip.
- No production code was changed; this is a test-only addition establishing a regression guard for the ratio math called out in this repo's dev-loop skill as previously untested.

## Backlog note

No open issues or PRs existed at the start of this cycle, so a test-expansion cycle (Stage B) was selected in place of issue implementation, per the dev-loop skill's guidance to favor documentation/test cycles when the backlog is thin.

## Test plan

- [x] `mvn -o clean package` — build succeeds
- [x] `mvn -o test` — 8 tests run (2 pre-existing + 6 new), 0 failures, 0 errors

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->