### PR TITLE
ci: publish a rolling dev prerelease from main

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,90 @@
+name: Dev Release
+
+# Publishes a rolling prerelease of the main branch so that server operators can opt into
+# unreleased changes via Dan's Plugin Manager (`/dpm get kdrtracker --experimental`).
+#
+# The build steps deliberately mirror release.yml — if the release build changes, change it here too.
+
+on:
+  push:
+    branches: [ main ]
+    # A documentation-only merge produces an identical JAR, so it is not worth a new prerelease
+    # (and the release notification it sends to every watcher of this repository).
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# The publish step deletes and recreates the release, so two runs must never overlap.
+# Queue instead of cancelling: a cancelled run could leave the repository with no dev release at all.
+concurrency:
+  group: dev-release
+  cancel-in-progress: false
+
+jobs:
+  dev-release:
+    runs-on: ubuntu-latest
+    # Forks have neither the release to publish to nor a reason to publish one.
+    if: github.repository == 'Dans-Plugins/KDRTracker'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Maven
+        run: mvn clean package
+
+      - name: Republish the dev prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          # Dan's Plugin Manager installs the first .jar asset it finds on the release, so publishing
+          # more than one would leave the installed build depending on asset order. An empty or
+          # ambiguous match fails the run rather than publishing something unpredictable.
+          # release.yml publishes target/*.jar minus the shade plugin's original-*.jar; the same
+          # selection is made here, then asserted to be unambiguous.
+          jars=()
+          for jar in target/*.jar; do
+            case "$(basename "$jar")" in original-*) continue ;; esac
+            jars+=("$jar")
+          done
+          if [ ${#jars[@]} -ne 1 ]; then
+            echo "Expected exactly one JAR to publish, found ${#jars[@]}: ${jars[*]:-none}" >&2
+            exit 1
+          fi
+
+          # The dev tag has to move to the new commit. Editing a published release does not move its
+          # tag, so the release and its tag are deleted and recreated. This leaves a window of a few
+          # seconds with no dev release; a client that fetches during it sees "no experimental build
+          # published" and succeeds on the next attempt.
+          gh release delete dev --yes --cleanup-tag || true
+
+          gh release create dev \
+            --prerelease \
+            --target "$GITHUB_SHA" \
+            --title "Development build" \
+            --notes "Automated build of \`main\` at ${GITHUB_SHA}.
+
+          **This is not a release.** It is unreleased, unreviewed code that has not been through any
+          release check, and a broken build can stop a server from starting. Do not run it on a server
+          you care about without a backup.
+
+          Install it with Dan's Plugin Manager:
+
+          \`\`\`
+          /dpm get kdrtracker --experimental
+          \`\`\`
+
+          Return to published releases with \`/dpm get kdrtracker --stable\`." \
+            "${jars[0]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- A `Dev Release` workflow, which republishes a rolling `dev` prerelease of `main` on every non-documentation push. This is what Dan's Plugin Manager's experimental channel installs from: `/dpm get kdrtracker --experimental` reads `releases/tags/dev`, so without it there is nothing for that command to download. The prerelease is unreleased, unreviewed code and is marked as such.
+
 ## [0.2.0-SNAPSHOT-8-8-2026] – 2026-08-08
 
 ### Changed


### PR DESCRIPTION
Part of the rollout behind Dan's Plugin Manager's experimental release channel. DPM can now install main-branch builds with `/dpm get kdrtracker --experimental`, which reads `releases/tags/dev` — but nothing in this organisation publishes such a release yet, so there is currently nothing for that command to download. This workflow publishes it.

## What it does

On every push to `main` that touches something other than documentation, the JAR is rebuilt and republished as a prerelease tagged `dev`. Because it is marked as a prerelease, GitHub's "latest release" is unaffected and plugins on the stable channel see no change.

## Notes on the approach

- **The build steps mirror `release.yml` deliberately** (Maven, same JDK, same artifact path). If the release build changes, this file has to change with it — a comment at the top says so.
- **The release is deleted and recreated rather than edited.** Editing a published release does not move its tag to the new commit, and DPM derives each build's version identity from the release's `target_commitish`. Recreating it with `--target "$GITHUB_SHA"` is what makes `dev-<short sha>` change from build to build; without it every build would look identical and DPM would report "already up to date" forever. A `concurrency` group prevents two runs overlapping on that delete-and-recreate, and queues rather than cancels, since a cancelled run could leave the repository with no dev release at all.
- **Exactly one JAR is asserted before publishing.** DPM installs the first `.jar` asset it finds on the release, so a release carrying two JARs would leave the installed build depending on asset order. An empty or ambiguous glob match now fails the run instead.
- **Documentation-only merges are skipped**, since they produce an identical JAR and would only add a release notification for every watcher.
- **Forks are excluded** by a repository guard.

## Verification

The same workflow was merged to Medieval-Factions first and confirmed end to end: the published release returned a 40-character commit sha in `target_commitish`, DPM's parser turned it into `dev-cc688da`, the JAR downloaded anonymously over HTTP 200 with no token, and `releases/latest` still returned the real release rather than the prerelease.

The first run of this workflow will be visible on `main` immediately after merge.

---

_drafted by Claude on behalf of Daniel Stephenson_
