### PR TITLE
Round the K/D ratio shown by /kdrt info and correct doc drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Changed
-
-- The K/D ratio shown by `/kdrt info` is now rounded to two decimal places instead of being printed at full floating-point precision, so a player with 1 kill and 3 deaths sees `K/D Ratio: 0.33` rather than `K/D Ratio: 0.3333333333333333`. The stored kill and death counts and the underlying ratio calculation are unchanged.
-
 ### Added
 
 - A `Dev Release` workflow, which republishes a rolling `dev` prerelease of `main` on every non-documentation push. This is what Dan's Plugin Manager's experimental channel installs from: `/dpm get kdrtracker --experimental` reads `releases/tags/dev`, so without it there is nothing for that command to download. The prerelease is unreleased, unreviewed code and is marked as such.
+
+### Changed
+
+- The K/D ratio shown by `/kdrt info` is now rounded to two decimal places instead of being printed at full floating-point precision, so a player with 1 kill and 3 deaths sees `K/D Ratio: 0.33` rather than `K/D Ratio: 0.3333333333333333`. The stored kill and death counts and the underlying ratio calculation are unchanged.
 
 ## [0.2.0-SNAPSHOT-8-8-2026] – 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- The K/D ratio shown by `/kdrt info` is now rounded to two decimal places instead of being printed at full floating-point precision, so a player with 1 kill and 3 deaths sees `K/D Ratio: 0.33` rather than `K/D Ratio: 0.3333333333333333`. The stored kill and death counts and the underlying ratio calculation are unchanged.
+
 ### Added
 
 - A `Dev Release` workflow, which republishes a rolling `dev` prerelease of `main` on every non-documentation push. This is what Dan's Plugin Manager's experimental channel installs from: `/dpm get kdrtracker --experimental` reads `releases/tags/dev`, so without it there is nothing for that command to download. The prerelease is unreleased, unreviewed code and is marked as such.

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -4,5 +4,6 @@ All commands use `/kdrt` or `/kdrtracker` as the base.
 
 | Command | Description | Permission |
 |---------|-------------|------------|
+| `/kdrt` | View the plugin version, developer, and wiki link. | *(none)* |
 | `/kdrt help` | View a list of commands. | `kdrt.help` |
 | `/kdrt info` (alias: `/kdrt view`) | View your kills, deaths, and K/D ratio. | `kdrt.info` |

--- a/PLANNING.md
+++ b/PLANNING.md
@@ -4,7 +4,7 @@ The purpose of the KDR Tracker is to keep track of the kill/death ratio of playe
 Players should be able to view their kill/death ratio and view a relevant leaderboard.
 
 ## Goals
-- [ ] Allow players to view their kill/death ratio.
+- [x] Allow players to view their kill/death ratio.
 - [ ] Allow players to view a relevant leaderboard.
 - [ ] Allow players to view the kill/death ratio of another player.
 

--- a/src/main/java/dansplugins/kdrtracker/commands/InfoCommand.java
+++ b/src/main/java/dansplugins/kdrtracker/commands/InfoCommand.java
@@ -9,6 +9,7 @@ import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Locale;
 
 import static org.bukkit.ChatColor.AQUA;
 
@@ -47,12 +48,21 @@ public class InfoCommand extends AbstractPluginCommand {
 
         player.sendMessage(AQUA + "Kills: " + kills);
         player.sendMessage(AQUA + "Deaths: " + deaths);
-        player.sendMessage(AQUA + "K/D Ratio: " + playerRecord.getRatio());
+        player.sendMessage(AQUA + "K/D Ratio: " + formatRatio(playerRecord.getRatio()));
         return true;
     }
 
     @Override
     public boolean execute(CommandSender commandSender, String[] strings) {
         return execute(commandSender);
+    }
+
+    /**
+     * Formats a K/D ratio for display in chat.
+     * @param ratio The ratio to format.
+     * @return The ratio rounded to two decimal places, using a period as the decimal separator regardless of the server's locale.
+     */
+    static String formatRatio(double ratio) {
+        return String.format(Locale.ROOT, "%.2f", ratio);
     }
 }

--- a/src/test/java/dansplugins/kdrtracker/commands/InfoCommandTest.java
+++ b/src/test/java/dansplugins/kdrtracker/commands/InfoCommandTest.java
@@ -1,0 +1,47 @@
+package dansplugins.kdrtracker.commands;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Daniel McCoy Stephenson
+ *
+ * Regression coverage for the K/D ratio shown to players being rounded for
+ * display, rather than printed at full floating-point precision.
+ */
+class InfoCommandTest {
+
+    @Test
+    void formatRatio_roundsRecurringDecimalDown() {
+        assertEquals("0.33", InfoCommand.formatRatio(1.0 / 3.0));
+    }
+
+    @Test
+    void formatRatio_roundsRecurringDecimalUp() {
+        assertEquals("0.67", InfoCommand.formatRatio(2.0 / 3.0));
+    }
+
+    @Test
+    void formatRatio_padsWholeNumbersToTwoPlaces() {
+        assertEquals("5.00", InfoCommand.formatRatio(5.0));
+    }
+
+    @Test
+    void formatRatio_formatsZero() {
+        assertEquals("0.00", InfoCommand.formatRatio(0.0));
+    }
+
+    @Test
+    void formatRatio_usesAPeriodAsTheDecimalSeparatorRegardlessOfTheDefaultLocale() {
+        Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.GERMANY);
+            assertEquals("1.50", InfoCommand.formatRatio(1.5));
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- The K/D ratio reported by `/kdrt info` is now rounded to two decimal places for display. A player with 1 kill and 3 deaths is shown `K/D Ratio: 0.33` instead of `K/D Ratio: 0.3333333333333333`. The formatting is applied in `InfoCommand` only — `PlayerRecord.getRatio()`, the stored kill/death counts, and the on-disk data format are untouched.
- `Locale.ROOT` is used for the format so that servers running under a comma-decimal default locale are not shown `0,33`. This is covered by a dedicated test that flips the default locale to `Locale.GERMANY`.
- The implemented goal "Allow players to view their kill/death ratio." is checked off in `PLANNING.md`. The two remaining goals (leaderboard, viewing another player's ratio) stay unchecked, as no source references either.
- The base `/kdrt` command is documented in `COMMANDS.md`. It is dispatched directly by `KDRTracker.onCommand()` when no arguments are supplied, bypassing Ponder's command service, so no permission is checked for it.
- A `CHANGELOG.md` entry has been added under `[Unreleased]`.

## Test plan

- [x] `mvn clean package` — BUILD SUCCESS, 13 tests run, 0 failures (8 pre-existing, 5 new).
- [x] Regression evidence for the ratio fix, gathered empirically rather than by reasoning: with `formatRatio` reverted to the pre-fix `"" + ratio` behaviour, all 5 new tests fail with exactly the raw-precision output (`expected: <0.33> but was: <0.3333333333333333>`, `expected: <1.50> but was: <1.5>`, and so on). With the fix restored, all 13 pass.
- [x] `src/main/resources/plugin.yml` is not modified; no command or permission registration changes.

## Deferred work

The following issues were filed during triage this cycle and deliberately left out of this PR:

- #12 (shaded JAR bundles JUnit 4 and Hamcrest) — the fix requires `pom.xml` dependency exclusions, which govern the artifact shipped to servers and warrant manual review rather than being bundled into a display/doc change.
- #13 (unreachable config-editing surface in `ConfigService`) — a dead-code removal in a different subsystem, kept separate to preserve a reviewable scope here.

Closes #9
Closes #10
Closes #11

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->

---

_drafted by Claude on behalf of Daniel Stephenson_