### PR TITLE
Remove the unreachable config-editing surface from ConfigService

### DIFF
--- a/src/main/java/dansplugins/kdrtracker/KDRTracker.java
+++ b/src/main/java/dansplugins/kdrtracker/KDRTracker.java
@@ -38,7 +38,7 @@ public final class KDRTracker extends PonderBukkitPlugin {
     // services
     private final CommandService commandService = new CommandService(getPonder());
     private final ConfigService configService = new ConfigService(this);
-    private final StorageService storageService = new StorageService(configService, this, persistentData, playerRecordFactory);
+    private final StorageService storageService = new StorageService(persistentData, playerRecordFactory);
 
     /**
      * This runs when the server starts.

--- a/src/main/java/dansplugins/kdrtracker/services/ConfigService.java
+++ b/src/main/java/dansplugins/kdrtracker/services/ConfigService.java
@@ -1,15 +1,11 @@
 package dansplugins.kdrtracker.services;
 
 /*
-    To add a new config option, the following methods must be altered:
-    - saveMissingConfigDefaultsIfNotPresent
-    - setConfigOption()
-    - sendConfigList()
+    To add a new config option, saveMissingConfigDefaultsIfNotPresent must be
+    altered and the option documented in CONFIG.md.
  */
 
 import dansplugins.kdrtracker.KDRTracker;
-import org.bukkit.ChatColor;
-import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 
 /**
@@ -17,7 +13,6 @@ import org.bukkit.configuration.file.FileConfiguration;
  */
 public class ConfigService {
     private final KDRTracker kdrTracker;
-    private boolean altered = false;
 
     public ConfigService(KDRTracker kdrTracker) {
         this.kdrTracker = kdrTracker;
@@ -38,43 +33,6 @@ public class ConfigService {
         kdrTracker.saveConfig();
     }
 
-    public void setConfigOption(String option, String value, CommandSender sender) {
-        if (getConfig().isSet(option)) {
-            if (option.equalsIgnoreCase("version")) {
-                sender.sendMessage(ChatColor.RED + "Cannot set version.");
-                return;
-            } else if (option.equalsIgnoreCase("A")) {
-                getConfig().set(option, Integer.parseInt(value));
-                sender.sendMessage(ChatColor.GREEN + "Integer set.");
-            } else if (option.equalsIgnoreCase("debugMode")) {
-                getConfig().set(option, Boolean.parseBoolean(value));
-                sender.sendMessage(ChatColor.GREEN + "Boolean set.");
-            } else if (option.equalsIgnoreCase("C")) {
-                getConfig().set(option, Double.parseDouble(value));
-                sender.sendMessage(ChatColor.GREEN + "Double set.");
-            } else {
-                getConfig().set(option, value);
-                sender.sendMessage(ChatColor.GREEN + "String set.");
-            }
-
-            // save
-            kdrTracker.saveConfig();
-            altered = true;
-        } else {
-            sender.sendMessage(ChatColor.RED + "That config option wasn't found.");
-        }
-    }
-
-    public void sendConfigList(CommandSender sender) {
-        sender.sendMessage(ChatColor.AQUA + "=== Config List ===");
-        sender.sendMessage(ChatColor.AQUA + "version: " + getConfig().getString("version")
-                + ", debugMode: " + getString("debugMode"));
-    }
-
-    public boolean hasBeenAltered() {
-        return altered;
-    }
-
     public FileConfiguration getConfig() {
         return kdrTracker.getConfig();
     }
@@ -83,43 +41,7 @@ public class ConfigService {
         return getConfig().isSet(option);
     }
 
-    public int getInt(String option) {
-        return getConfig().getInt(option);
-    }
-
-    public int getIntOrDefault(String option, int defaultValue) {
-        int toReturn = getInt(option);
-        if (toReturn == 0) {
-            return defaultValue;
-        }
-        return toReturn;
-    }
-
     public boolean getBoolean(String option) {
         return getConfig().getBoolean(option);
-    }
-
-    public double getDouble(String option) {
-        return getConfig().getDouble(option);
-    }
-
-    public double getDoubleOrDefault(String option, double defaultValue) {
-        double toReturn = getDouble(option);
-        if (toReturn == 0) {
-            return defaultValue;
-        }
-        return toReturn;
-    }
-
-    public String getString(String option) {
-        return getConfig().getString(option);
-    }
-
-    public String getStringOrDefault(String option, String defaultValue) {
-        String toReturn = getString(option);
-        if (toReturn == null) {
-            return defaultValue;
-        }
-        return toReturn;
     }
 }

--- a/src/main/java/dansplugins/kdrtracker/services/StorageService.java
+++ b/src/main/java/dansplugins/kdrtracker/services/StorageService.java
@@ -1,6 +1,5 @@
 package dansplugins.kdrtracker.services;
 
-import dansplugins.kdrtracker.KDRTracker;
 import dansplugins.kdrtracker.data.PersistentData;
 import dansplugins.kdrtracker.factories.PlayerRecordFactory;
 import preponderous.ponder.misc.JsonWriterReader;
@@ -15,8 +14,6 @@ import java.util.Map;
  * This class is intended to handle the storage of data for the plugin.
  */
 public class StorageService {
-    private final ConfigService configService;
-    private final KDRTracker kdrTracker;
     private final PersistentData persistentData;
     private final PlayerRecordFactory playerRecordFactory;
 
@@ -25,9 +22,7 @@ public class StorageService {
     private final String FILE_PATH = "./plugins/KDRTracker/";
     private final String PLAYER_RECORDS_FILE_NAME = "playerRecords.json";
 
-    public StorageService(ConfigService configService, KDRTracker kdrTracker, PersistentData persistentData, PlayerRecordFactory playerRecordFactory) {
-        this.configService = configService;
-        this.kdrTracker = kdrTracker;
+    public StorageService(PersistentData persistentData, PlayerRecordFactory playerRecordFactory) {
         this.persistentData = persistentData;
         this.playerRecordFactory = playerRecordFactory;
         jsonWriterReader.initialize(FILE_PATH);
@@ -35,9 +30,6 @@ public class StorageService {
 
     public void save() {
         savePlayerRecords();
-        if (configService.hasBeenAltered()) {
-            kdrTracker.saveConfig();
-        }
     }
 
     public void load() {


### PR DESCRIPTION
## Summary

- `setConfigOption(String, String, CommandSender)` and `sendConfigList(CommandSender)` are removed from `ConfigService`. Neither had a call site anywhere in `src/main/java` — no config command is registered in `KDRTracker.initializeCommandService()`, so neither could be reached at runtime. `setConfigOption` also branched on placeholder option names `"A"` and `"C"`, which do not exist in this plugin's config, and `sendConfigList` read the boolean `debugMode` through `getString(...)`.
- With `setConfigOption` gone, the `altered` field could never become `true`, so `hasBeenAltered()` is removed along with the `StorageService.save()` branch that guarded a redundant `saveConfig()` call. `StorageService`'s `configService` and `kdrTracker` fields are now unused and are dropped from the class and its constructor; the single construction site in `KDRTracker` is updated to match.
- `getIntOrDefault`, `getDoubleOrDefault` and `getStringOrDefault` were already uncalled and are removed. `getInt`, `getDouble` and `getString` were reachable only from those helpers and from `sendConfigList`, so they are removed with them. `getConfig()`, `isSet(...)` and `getBoolean(...)` are kept — `getBoolean` is called by `KDRTracker.isDebugEnabled()`, and `getConfig()` remains available for reads that need a type this class does not wrap.
- The file header comment, which instructed contributors to keep the unreachable methods in sync when adding a config option, now points at `saveMissingConfigDefaultsIfNotPresent` and `CONFIG.md`.

No behaviour change is expected: every removed method was unreachable, and the removed `StorageService` branch could never be taken.

## Note on scope

Only the accessors named above are removed. Removing `getInt`/`getDouble`/`getString` goes one step past the issue's own enumeration — those three were live when the issue was written, and became dead only once their sole callers were deleted here. Leaving them behind would have reintroduced exactly what the issue reports, so they were removed in the same pass. If the typed accessor set is wanted as a forward-looking API, restoring them is a one-line-each revert.

## Test plan

- [x] `mvn clean package` — BUILD SUCCESS, 13 tests run, 0 failures, 0 errors
- [x] `grep` across `src/` and all Markdown docs confirms no remaining reference to `setConfigOption`, `sendConfigList`, `hasBeenAltered`, or the removed accessors
- [x] Documentation sweep: `CONFIG.md` documents only `version` and `debugMode`, both untouched; `COMMANDS.md`, `USER_GUIDE.md`, `PLANNING.md`, `README.md` and `plugin.yml` contain no reference to a config command or to config editing
- [x] No `CHANGELOG.md` entry is added, as no user-facing or operator-facing behaviour changes
- [x] Kill/death accounting and `PlayerRecord.getRatio()` are untouched by this PR

## Merge gate

`ConfigService.java` loses roughly 80 lines, which trips this loop's do-not-auto-merge rule for a single file with more than 50 lines deleted. Autonomous merge is therefore withheld and maintainer review is requested, even though the deletion is the substance of the linked issue.

## Deferred this cycle

Issue #12 (JUnit and Hamcrest shaded into the plugin JAR from `ponder`'s compile-scope dependencies) was not picked up. Its fix edits `pom.xml`, which governs the shaded artifact shipped to servers and is likewise on the do-not-auto-merge list; it is better served by a dedicated, separately reviewed PR than by being batched with an unrelated cleanup. The shading behaviour it describes was re-confirmed in this cycle's build output and remains accurate.

Closes #13

<!-- gardener-tend-dispatch -->

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

---

_drafted by Claude on behalf of Daniel Stephenson_